### PR TITLE
Allow sending and receiving arrays that are not contiguous

### DIFF
--- a/numba_mpi/mpi.py
+++ b/numba_mpi/mpi.py
@@ -160,7 +160,7 @@ def send(data, dest, tag):
 
     # The following no-op prevents numba from too aggressive optimizations
     # This looks like a bug in numba (tested for version 0.55)
-    data[0]
+    data[0]  # pylint: disable=pointless-statement
 
 
 @numba.njit()

--- a/numba_mpi/mpi.py
+++ b/numba_mpi/mpi.py
@@ -175,13 +175,13 @@ def recv(data, source, tag):
     )
 
     result = _MPI_Recv(
-        data.ctypes.data,
-        data.size,
+        buffer.ctypes.data,
+        buffer.size,
         _mpi_double(),
         source,
         tag,
         _mpi_comm_world(),
-        status.ctypes.data,
+        status.ctypes.data
     )
     assert result == 0
 

--- a/numba_mpi/mpi.py
+++ b/numba_mpi/mpi.py
@@ -157,10 +157,10 @@ def send(data, dest, tag):
         _mpi_comm_world()
     )
     assert result == 0
-    
-    # the following no-op prevents numba from too aggressive optimizations
+
+    # The following no-op prevents numba from too aggressive optimizations
     # This looks like a bug in numba (tested for version 0.55)
-    data += 0
+    data[0]
 
 
 @numba.njit()
@@ -180,7 +180,7 @@ def recv(data, source, tag):
             status.ctypes.data,
         )
         assert result == 0
-        
+
     else:
         # write data to buffer and copy it into non-contiguous array
         buffer = np.zeros_like(data)

--- a/numba_mpi/mpi.py
+++ b/numba_mpi/mpi.py
@@ -157,6 +157,10 @@ def send(data, dest, tag):
         _mpi_comm_world()
     )
     assert result == 0
+    
+    # the following no-op prevents numba from too aggressive optimizations
+    # This looks like a bug in numba (tested for version 0.55)
+    data += 0
 
 
 @numba.njit()
@@ -176,10 +180,10 @@ def recv(data, source, tag):
             status.ctypes.data,
         )
         assert result == 0
-
+        
     else:
-        # write data into buffer and copy into non-contiguous array
-        buffer = np.empty_like(data)
+        # write data to buffer and copy it into non-contiguous array
+        buffer = np.zeros_like(data)
         result = _MPI_Recv(
             buffer.ctypes.data,
             buffer.size,

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -53,15 +53,11 @@ class TestMPI:
     def test_send_recv_noncontiguous(snd, rcv, data_type):
         src = np.array([1, 2, 3, 4, 5], dtype=data_type)
         dst_tst = np.zeros(5, dtype=data_type)
-        dst_exp = np.zeros(5, dtype=data_type)
 
         if mpi.rank() == 0:
             snd(src[::2], dest=1, tag=11)
-            COMM_WORLD.Send(src[::2], dest=1, tag=22)
         elif mpi.rank() == 1:
             rcv(dst_tst[::2], source=0, tag=11)
-            COMM_WORLD.Recv(dst_exp[::2], source=0, tag=22)
 
             assert np.all(dst_tst[1::2] == 0)
             assert np.all(dst_tst[::2] == src[::2])
-            assert np.all(dst_tst == dst_exp)

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -43,3 +43,25 @@ class TestMPI:
 
             assert np.all(dst_tst == src)
             assert np.all(dst_tst == dst_exp)
+
+    @staticmethod
+    @pytest.mark.parametrize("snd, rcv", [
+        (mpi.send, mpi.recv),
+        (mpi.send.py_func, mpi.recv.py_func)
+    ])
+    @pytest.mark.parametrize("data_type", [np.float64])
+    def test_send_recv_noncontiguous(snd, rcv, data_type):
+        src = np.array([1, 2, 3, 4, 5], dtype=data_type)
+        dst_tst = np.zeros(5, dtype=data_type)
+        dst_exp = np.zeros(5, dtype=data_type)
+
+        if mpi.rank() == 0:
+            snd(src[::2], dest=1, tag=11)
+            COMM_WORLD.Send(src[::2], dest=1, tag=22)
+        elif mpi.rank() == 1:
+            rcv(dst_tst[::2], source=0, tag=11)
+            COMM_WORLD.Recv(dst_exp[::2], source=0, tag=22)
+
+            assert np.all(dst_tst[1::2] == 0)
+            assert np.all(dst_tst[::2] == src[::2])
+            assert np.all(dst_tst == dst_exp)


### PR DESCRIPTION
Added extra logic that copies data before sending and after receiving if it is not contiguous in memory.

Note that numba seems to have a bug where it doesn't copy the data into a contiguous array when it believes the data is not used. This can be circumvented with a weird no-op statement, but should be fixed upstream in the future.