### PR TITLE
Fixed `numba_mpi.recv` for 0d arrays

### DIFF
--- a/numba_mpi/mpi.py
+++ b/numba_mpi/mpi.py
@@ -186,4 +186,4 @@ def recv(data, source, tag):
     assert result == 0
 
     if not data.flags.c_contiguous:
-        data[:] = buffer
+        data[...] = buffer

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -24,10 +24,9 @@ class TestMPI:
         assert rank == COMM_WORLD.Get_rank()
 
     @staticmethod
-    @pytest.mark.parametrize("snd, rcv", [
-        (mpi.send, mpi.recv),
-        (mpi.send.py_func, mpi.recv.py_func)
-    ])
+    @pytest.mark.parametrize(
+        "snd, rcv", [(mpi.send, mpi.recv), (mpi.send.py_func, mpi.recv.py_func)]
+    )
     @pytest.mark.parametrize("data_type", [np.float64])
     def test_send_recv(snd, rcv, data_type):
         src = np.array([1, 2, 3, 4, 5], dtype=data_type)
@@ -45,10 +44,9 @@ class TestMPI:
             assert np.all(dst_tst == dst_exp)
 
     @staticmethod
-    @pytest.mark.parametrize("snd, rcv", [
-        (mpi.send, mpi.recv),
-        (mpi.send.py_func, mpi.recv.py_func)
-    ])
+    @pytest.mark.parametrize(
+        "snd, rcv", [(mpi.send, mpi.recv), (mpi.send.py_func, mpi.recv.py_func)]
+    )
     @pytest.mark.parametrize("data_type", [np.float64])
     def test_send_recv_noncontiguous(snd, rcv, data_type):
         src = np.array([1, 2, 3, 4, 5], dtype=data_type)
@@ -61,3 +59,19 @@ class TestMPI:
 
             assert np.all(dst_tst[1::2] == 0)
             assert np.all(dst_tst[::2] == src[::2])
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "snd, rcv", [(mpi.send, mpi.recv), (mpi.send.py_func, mpi.recv.py_func)]
+    )
+    @pytest.mark.parametrize("data_type", [np.float64])
+    def test_send_0d_arrays(snd, rcv, data_type):
+        src = np.array(1, dtype=data_type)
+        dst_tst = np.zeros_like(src)
+
+        if mpi.rank() == 0:
+            snd(src, dest=1, tag=11)
+        elif mpi.rank() == 1:
+            rcv(dst_tst, source=0, tag=11)
+
+            assert np.all(dst_tst == src)

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -24,9 +24,10 @@ class TestMPI:
         assert rank == COMM_WORLD.Get_rank()
 
     @staticmethod
-    @pytest.mark.parametrize(
-        "snd, rcv", [(mpi.send, mpi.recv), (mpi.send.py_func, mpi.recv.py_func)]
-    )
+    @pytest.mark.parametrize("snd, rcv", [
+        (mpi.send, mpi.recv),
+        (mpi.send.py_func, mpi.recv.py_func)
+    ])
     @pytest.mark.parametrize("data_type", [np.float64])
     def test_send_recv(snd, rcv, data_type):
         src = np.array([1, 2, 3, 4, 5], dtype=data_type)
@@ -44,13 +45,14 @@ class TestMPI:
             assert np.all(dst_tst == dst_exp)
 
     @staticmethod
-    @pytest.mark.parametrize(
-        "snd, rcv", [(mpi.send, mpi.recv), (mpi.send.py_func, mpi.recv.py_func)]
-    )
+    @pytest.mark.parametrize("snd, rcv", [
+        (mpi.send, mpi.recv),
+        (mpi.send.py_func, mpi.recv.py_func)
+    ])
     @pytest.mark.parametrize("data_type", [np.float64])
     def test_send_recv_noncontiguous(snd, rcv, data_type):
         src = np.array([1, 2, 3, 4, 5], dtype=data_type)
-        dst_tst = np.zeros(5, dtype=data_type)
+        dst_tst = np.zeros_like(src)
 
         if mpi.rank() == 0:
             snd(src[::2], dest=1, tag=11)
@@ -61,9 +63,10 @@ class TestMPI:
             assert np.all(dst_tst[::2] == src[::2])
 
     @staticmethod
-    @pytest.mark.parametrize(
-        "snd, rcv", [(mpi.send, mpi.recv), (mpi.send.py_func, mpi.recv.py_func)]
-    )
+    @pytest.mark.parametrize("snd, rcv", [
+        (mpi.send, mpi.recv),
+        (mpi.send.py_func, mpi.recv.py_func)
+    ])
     @pytest.mark.parametrize("data_type", [np.float64])
     def test_send_0d_arrays(snd, rcv, data_type):
         src = np.array(1, dtype=data_type)


### PR DESCRIPTION
Improved how data is written to the output and added a test to check for handling of 0d arrays.