### PR TITLE
Fixed sending fortran ordered arrays

### DIFF
--- a/numba_mpi/mpi.py
+++ b/numba_mpi/mpi.py
@@ -196,7 +196,7 @@ def recv(data, source, tag):
 
     buffer = (
         data if data.flags.c_contiguous
-        else np.empty(data.shape, data.dtype)
+        else np.empty_like(data, order='C')
     )
 
     result = _MPI_Recv(

--- a/numba_mpi/mpi.py
+++ b/numba_mpi/mpi.py
@@ -196,7 +196,7 @@ def recv(data, source, tag):
 
     buffer = (
         data if data.flags.c_contiguous
-        else np.empty_like(data, order='C')
+        else np.empty(data.shape, data.dtype)  # np.empty_like(data, order='C') fails with Numba
     )
 
     result = _MPI_Recv(

--- a/numba_mpi/mpi.py
+++ b/numba_mpi/mpi.py
@@ -196,7 +196,7 @@ def recv(data, source, tag):
 
     buffer = (
         data if data.flags.c_contiguous
-        else np.empty_like(data)
+        else np.empty(data.shape, data.dtype)
     )
 
     result = _MPI_Recv(

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -40,7 +40,7 @@ class TestMPI:
     def test_send_recv(snd, rcv, fortran_order, data_type):
         rng = np.random.default_rng(0)
         if np.issubdtype(data_type, np.complexfloating):
-            src = rng.random((3, 3)) + rng.random((3, 3)) * 1j 
+            src = rng.random((3, 3)) + rng.random((3, 3)) * 1j
         elif np.issubdtype(data_type, np.integer):
             src = rng.integers(0, 10, size=(3, 3))
         else:

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -35,11 +35,24 @@ class TestMPI:
         (mpi.send, mpi.recv),
         (mpi.send.py_func, mpi.recv.py_func)
     ])
+    @pytest.mark.parametrize("fortran_order", [True, False])
     @pytest.mark.parametrize("data_type", data_types)
-    def test_send_recv(snd, rcv, data_type):
-        src = np.array([1, 2, 3, 4, 5], dtype=data_type)
-        dst_tst = np.empty(5, dtype=data_type)
-        dst_exp = np.empty(5, dtype=data_type)
+    def test_send_recv(snd, rcv, fortran_order, data_type):
+        rng = np.random.default_rng(0)
+        if np.issubdtype(data_type, np.complexfloating):
+            src = rng.random((3, 3)) + rng.random((3, 3)) * 1j 
+        elif np.issubdtype(data_type, np.integer):
+            src = rng.integers(0, 10, size=(3, 3))
+        else:
+            src = rng.random((3, 3))
+
+        if fortran_order:
+            src = np.asfortranarray(src, dtype=data_type)
+        else:
+            src = src.astype(dtype=data_type)
+
+        dst_exp = np.empty_like(src)
+        dst_tst = np.empty_like(src)
 
         if mpi.rank() == 0:
             snd(src, dest=1, tag=11)
@@ -49,7 +62,7 @@ class TestMPI:
             COMM_WORLD.Recv(dst_exp, source=0, tag=22)
 
             np.testing.assert_equal(dst_tst, src)
-            np.testing.assert_equal(dst_tst, dst_exp)
+            np.testing.assert_equal(dst_exp, src)
 
     @staticmethod
     @pytest.mark.parametrize("snd, rcv", [
@@ -77,7 +90,7 @@ class TestMPI:
     @pytest.mark.parametrize("data_type", data_types)
     def test_send_0d_arrays(snd, rcv, data_type):
         src = np.array(1, dtype=data_type)
-        dst_tst = np.zeros_like(src)
+        dst_tst = np.empty_like(src)
 
         if mpi.rank() == 0:
             snd(src, dest=1, tag=11)


### PR DESCRIPTION
This PR fixes a bug where data of Fortran ordered arrays was transposed.