### PR TITLE
Added additional operators for `allreduce`

### DIFF
--- a/numba_mpi/__init__.py
+++ b/numba_mpi/__init__.py
@@ -1,2 +1,2 @@
 """ Numba @njittable MPI wrappers tested on Linux, macOS and Windows """
-from .mpi import initialized, size, rank, send, recv, allreduce
+from .mpi import initialized, size, rank, send, recv, allreduce, Operator

--- a/numba_mpi/mpi.py
+++ b/numba_mpi/mpi.py
@@ -38,9 +38,10 @@ _MpiOp = ctypes.c_int
 
 
 class Operator(IntEnum):
-    Max = MPI.MAX.py2f()
-    Min = MPI.MIN.py2f()
-    Sum = MPI.SUM.py2f()
+    """collection of operators that MPI supports"""
+    MAX = MPI.MAX.py2f()
+    MIN = MPI.MIN.py2f()
+    SUM = MPI.SUM.py2f()
 
 
 _MPI_Initialized = libmpi.MPI_Initialized
@@ -238,14 +239,14 @@ def recv(data, source, tag):
 
 
 @numba.generated_jit(nopython=True)
-def allreduce(data, operator=Operator.Sum):  # pylint: disable=unused-argument
+def allreduce(data, operator=Operator.SUM):  # pylint: disable=unused-argument
     """wrapper for MPI_Allreduce
 
     Note that complex datatypes and user-defined functions are not properly supported.
     """
     if isinstance(data, (types.Number, Number)):
 
-        def impl(data, operator=Operator.Sum):
+        def impl(data, operator=Operator.SUM):
             sendobj = np.array([data])
             recvobj = np.empty((1,), sendobj.dtype)
 
@@ -267,7 +268,7 @@ def allreduce(data, operator=Operator.Sum):  # pylint: disable=unused-argument
 
     elif isinstance(data, (types.Array, np.ndarray)):
 
-        def impl(data, operator=Operator.Sum):
+        def impl(data, operator=Operator.SUM):
             sendobj = np.ascontiguousarray(data)
             recvobj = np.empty(sendobj.shape, sendobj.dtype)
 

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -111,9 +111,9 @@ class TestMPI:
 
     @staticmethod
     @pytest.mark.parametrize("allreduce", [mpi.allreduce, allreduce_pyfunc])
-    @pytest.mark.parametrize("op_mpi, op_np", [(mpi.Operator.Sum, np.sum),
-                                               (mpi.Operator.Min, np.min),
-                                               (mpi.Operator.Max, np.max)])
+    @pytest.mark.parametrize("op_mpi, op_np", [(mpi.Operator.SUM, np.sum),
+                                               (mpi.Operator.MIN, np.min),
+                                               (mpi.Operator.MAX, np.max)])
     @pytest.mark.parametrize("data_type", data_types_real)
     def test_allreduce(allreduce, op_mpi, op_np, data_type):
         # test arrays

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -6,12 +6,18 @@ import numba_mpi as mpi
 
 
 def get_random_array(shape, data_type):
+    """helper function creating the same random array in each process"""
     rng = np.random.default_rng(0)
     if np.issubdtype(data_type, np.complexfloating):
         return rng.random(shape) + rng.random(shape) * 1j
     if np.issubdtype(data_type, np.integer):
         return rng.integers(0, 10, size=shape)
     return rng.random(shape)
+
+
+def allreduce_pyfunc(data, operator):
+    """helper function to call pyfunc of allreduce without jitting"""
+    return mpi.allreduce.py_func(data, operator)(data, operator)
 
 
 class TestMPI:
@@ -104,23 +110,28 @@ class TestMPI:
             np.testing.assert_equal(dst_tst, src)
 
     @staticmethod
-    @pytest.mark.parametrize("allreduce",
-                             [mpi.allreduce, lambda x: mpi.allreduce.py_func(x)(x)])  # pylint: disable=unnecessary-lambda
+    @pytest.mark.parametrize("allreduce", [mpi.allreduce, allreduce_pyfunc])
+    @pytest.mark.parametrize("op_mpi, op_np", [(mpi.Operator.Sum, np.sum),
+                                               (mpi.Operator.Min, np.min),
+                                               (mpi.Operator.Max, np.max)])
     @pytest.mark.parametrize("data_type", data_types_real)
-    def test_allreduce(allreduce, data_type):
+    def test_allreduce(allreduce, op_mpi, op_np, data_type):
         # test arrays
         src = get_random_array((3,), data_type)
-        res = allreduce(src)
-        np.testing.assert_equal(res, mpi.size() * src)
+        res = allreduce(src, operator=op_mpi)
+        expect = op_np(np.tile(src, [mpi.size(), 1]), axis=0)
+        np.testing.assert_equal(res, expect)
 
         # test scalars
         src = src[0]
-        res = allreduce(src)
+        res = allreduce(src, operator=op_mpi)
         assert np.isscalar(res)
-        np.testing.assert_equal(res, mpi.size() * src)
+        expect = op_np(np.tile(src, [mpi.size(), 1]), axis=0)
+        np.testing.assert_equal(res, expect)
 
         # test 0d arrays
         src = get_random_array((), data_type)
-        res = allreduce(src)
+        res = allreduce(src, operator=op_mpi)
         assert not np.isscalar(res)
-        np.testing.assert_equal(res, mpi.size() * src)
+        expect = op_np(np.tile(src, [mpi.size(), 1]), axis=0)
+        np.testing.assert_equal(res, expect)


### PR DESCRIPTION
I called the enum that contains the defined operators `Operators` because I like expressive names, but we could also change it to `Op` to be closer to the original MPI definition.