### PR TITLE
MPI_Error_class: add wraper and pytest

### DIFF
--- a/numba_mpi/__init__.py
+++ b/numba_mpi/__init__.py
@@ -7,6 +7,7 @@ from importlib.metadata import PackageNotFoundError, version
 from .api.allreduce import allreduce
 from .api.barrier import barrier
 from .api.bcast import bcast
+from .api.error_class import error_class
 from .api.initialized import initialized
 from .api.irecv import irecv
 from .api.isend import isend

--- a/numba_mpi/api/error_class.py
+++ b/numba_mpi/api/error_class.py
@@ -1,0 +1,26 @@
+"""MPI_Error_class() wrapper"""
+
+import ctypes
+
+import numba
+import numpy as np
+
+from numba_mpi.common import libmpi
+
+_MPI_Error_class = libmpi.MPI_Error_class
+_MPI_Error_class.restype = ctypes.c_int
+_MPI_Error_class.argtypes = [ctypes.c_int, ctypes.c_void_p]
+
+
+@numba.njit()
+def error_class(error_code):
+    """
+    Wrapper for MPI_Error_class()
+    """
+    value = np.empty(1, dtype=np.intc)
+    status = _MPI_Error_class(error_code, value.ctypes.data)
+
+    if status != 0:
+        value[0] = 0
+
+    return value[0]

--- a/tests/api/test_error_class.py
+++ b/tests/api/test_error_class.py
@@ -1,0 +1,24 @@
+# pylint: disable=missing-function-docstring,missing-class-docstring,missing-module-docstring
+import pytest
+from mpi4py import MPI
+
+import numba_mpi as mpi
+
+
+@pytest.mark.parametrize(
+    argnames="sut", argvalues=(mpi.error_class, mpi.error_class.py_func)
+)
+@pytest.mark.parametrize(
+    "err_const",
+    [
+        0,
+        MPI.ERR_ARG,
+        MPI.ERR_COMM,
+        MPI.ERR_RANK,
+        MPI.ERR_TYPE,
+    ],
+)
+def test_error_class(sut, err_const):
+    result = sut(err_const)
+
+    assert result == MPI.Get_error_class(err_const)


### PR DESCRIPTION
Closing #152

Added wrapper for `MPI_Error_class` and `test_error_class.py` to test using pytest.
